### PR TITLE
hide page while locale is loading

### DIFF
--- a/css/dns.css
+++ b/css/dns.css
@@ -21,6 +21,7 @@ body {
     display: flex;
     flex-direction: column;
     justify-content: space-between;
+    transition: 0.1s opacity;
 }
 
 * {
@@ -37,6 +38,10 @@ body.scroll__disabled {
     top: 0;
     bottom: 0;
     right: 0;
+}
+
+body.hidden{
+    opacity: 0;
 }
 
 .btn {

--- a/index.html
+++ b/index.html
@@ -51,7 +51,7 @@
         initTheme();
     </script>
 </head>
-<body>
+<body class="hidden">
 <nav>
     <div class="testnet-badge">
         <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 20 20" class="icon testnet__icon">

--- a/src/index.js
+++ b/src/index.js
@@ -110,6 +110,8 @@ if (lang !== 'en') {
     })
 }
 
+togglePageVisible()
+
 const IS_TESTNET = window.location.href.indexOf('testnet=true') > -1
 
 const AUCTION_START_TIME = IS_TESTNET ? 1659125865 : 1659171600

--- a/src/index.js
+++ b/src/index.js
@@ -1029,6 +1029,7 @@ function setCareeteHelperValue(value) {
     const resetInputIcon = $('.icon.reset__input--icon')
     const careeteHelper = $('.start-input-container__domain--container')
     const careeteHelperText = $('.start-input-container__domain')
+    const isValueContainDotTon = value?.length ? value.slice(value.length - 4) === '.ton' : false
 
     if (value !== oldStartInputValue) {
         oldStartInputValue = value;
@@ -1047,6 +1048,10 @@ function setCareeteHelperValue(value) {
                 careeteHelper.style.visibility = 'visible';
             }
         }
+    }
+
+    if(isValueContainDotTon){
+        careeteHelper.style.visibility = 'hidden';
     }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -347,3 +347,7 @@ window.BROWSER = (function (agent) {
 function encodeHTML(s) {
     return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/"/g, '&quot;');
 }
+
+function togglePageVisible(){
+    document.body.classList.toggle('hidden')
+}


### PR DESCRIPTION
Bug - tongue blinking on page load
Solution - add opacity to the page until all translations are loaded

Bug - Placeholder “.ton” is added to the “.ton” we specified at the end
Solution - hide .ton if it is already specified