### PR TITLE
change UTF symbol to UNICODE; remove dublicate charset literal

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <title>About</title>
     <meta charset="UTF-8" />
+    <title>About</title>
 
     <meta name="description" content="Give crypto wallets, smart contracts or websites short readable names." />
 

--- a/css/dns.css
+++ b/css/dns.css
@@ -1694,7 +1694,7 @@ p {
 }
 
 .converted__price:before {
-    content: '≈ $';
+    content: '\2248\ \ $';
 }
 
 .converted__percent:after {

--- a/index.html
+++ b/index.html
@@ -4,7 +4,6 @@
     <meta charset="UTF-8">
     <title>TON Domains</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, minimum-scale=1, user-scalable=no, minimal-ui, viewport-fit=cover">
-    <meta charSet="UTF-8" />
 
     <meta name="description" content="Give crypto wallets, smart contracts or websites short readable names." />
 


### PR DESCRIPTION
What options have been passed

1. The problem is in the font - the font may not support special characters. Discarded as all fonts used in the project have character support
2. The problem is in the browser. Older versions of the browser may not interpret special characters this way. The version of the browser in the issue is the same as mine.
3. The problem is in the system - the answer is the same as with the browser.
4. The character may have been copied from the platform in the wrong encoding. Mk is swept aside in this case, it would always be displayed broken.

In general, I have only one hypothesis - that this is due to the double specified encoding in different places in the html document. I propose to re-insert the symbol into UNICODE, remove the duplication of the charset and indicate that the bug is under monitoring - since it is not known how to reproduce it.